### PR TITLE
Fix failing tests

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -4,12 +4,25 @@ openapi_gen(
     name = "petstore",
     language = "go",
     spec = "petstore.yaml",
+    outputs = [
+        "model_error.go",
+        "model_pet.go",
+        "api_pets.go",
+        "configuration.go",
+        "client.go",
+        "response.go",
+        "go.mod",
+        "go.sum",
+    ]
 )
 
 openapi_gen(
     name = "petstore_java",
     language = "java",
     spec = "petstore.yaml",
+    outputs = [
+        "src/test/java/org/openapitools/client/model/PetTest.java",
+    ]
 )
 
 openapi_gen(
@@ -19,6 +32,10 @@ openapi_gen(
     },
     language = "java",
     spec = "petstore.yaml",
+    outputs = [
+        "src/main/java/org/openapitools/client/api/PetsApi.java",
+        "src/test/java/org/openapitools/client/api/PetsApiTest.java",
+    ]
 )
 
 openapi_gen(
@@ -29,6 +46,9 @@ openapi_gen(
         "apiTests": "false",
         "modelTests": "false",
     },
+    outputs = [
+        "src/main/java/org/openapitools/client/model/Pet.java",
+    ]
 )
 
 openapi_gen(
@@ -38,4 +58,7 @@ openapi_gen(
     type_mappings = {
         "Integer": "java.math.BigDecimal",
     },
+    outputs = [
+        "src/main/java/org/openapitools/client/model/Error.java",
+    ]
 )


### PR DESCRIPTION
Tests are currently failing from to the changes in the rule. These are handy to show how the forked `openapi_gen` rule can be used.

This pull request updates the tests to show how files can be pulled from the rule.