### PR TITLE
Output files at the rules bin directory equivalent instead of the directory of the swagger files path

### DIFF
--- a/openapi/openapi.bzl
+++ b/openapi/openapi.bzl
@@ -85,10 +85,9 @@ def _impl(ctx):
       "find {gen_dir} -exec touch -t 198001010000 {{}} \;".format(
          gen_dir=gen_dir
       ),
-      "cp -r {gen_dir}/* {bin_dir}/{dirname}".format(
+      "cp -r {gen_dir}/* {dirname}".format(
         gen_dir=gen_dir,
-        bin_dir=ctx.bin_dir.path,
-        dirname=ctx.file.spec.dirname
+        dirname="%s/%s" % (ctx.bin_dir.path, ctx.label.package)
       ),
     ]
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -4,12 +4,25 @@ openapi_gen(
     name = "petstore",
     language = "go",
     spec = "petstore.yaml",
+    outputs = [
+        "model_error.go",
+        "model_pet.go",
+        "api_pets.go",
+        "configuration.go",
+        "client.go",
+        "response.go",
+        "go.mod",
+        "go.sum",
+    ]
 )
 
 openapi_gen(
     name = "petstore_java",
     language = "java",
     spec = "petstore.yaml",
+    outputs = [
+        "src/test/java/org/openapitools/client/model/PetTest.java",
+    ]
 )
 
 openapi_gen(
@@ -19,6 +32,10 @@ openapi_gen(
     },
     language = "java",
     spec = "petstore.yaml",
+    outputs = [
+        "src/main/java/org/openapitools/client/api/PetsApi.java",
+        "src/test/java/org/openapitools/client/api/PetsApiTest.java",
+    ]
 )
 
 openapi_gen(
@@ -29,6 +46,9 @@ openapi_gen(
         "apiTests": "false",
         "modelTests": "false",
     },
+    outputs = [
+        "src/main/java/org/openapitools/client/model/Pet.java",
+    ]
 )
 
 openapi_gen(
@@ -38,4 +58,7 @@ openapi_gen(
     type_mappings = {
         "Integer": "java.math.BigDecimal",
     },
+    outputs = [
+        "src/main/java/org/openapitools/client/model/Error.java",
+    ]
 )

--- a/test/BUILD
+++ b/test/BUILD
@@ -62,3 +62,12 @@ openapi_gen(
         "src/main/java/org/openapitools/client/model/Error.java",
     ]
 )
+
+openapi_gen(
+    name = "output_in_rule_di",
+    language = "typescript-node",
+    spec = "nested/directory/petstore.yaml",
+    outputs = [
+        "api.ts"
+    ]
+)

--- a/test/nested/directory/petstore.yaml
+++ b/test/nested/directory/petstore.yaml
@@ -1,0 +1,101 @@
+swagger: "2.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+host: petstore.swagger.io
+basePath: /v1
+schemes:
+  - http
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          type: integer
+          format: int32
+      responses:
+        "200":
+          description: An paged array of pets
+          headers:
+            x-next:
+              type: string
+              description: A link to the next page of responses
+          schema:
+            $ref: '#/definitions/Pets'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      responses:
+        "201":
+          description: Null response
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /pets/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          type: string
+      responses:
+        "200":
+          description: Expected response to a valid request
+          schema:
+            $ref: '#/definitions/Pets'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+definitions:
+  Pet:
+    required:
+      - id
+      - name
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+      tag:
+        type: string
+  Pets:
+    type: array
+    items:
+      $ref: '#/definitions/Pet'
+  Error:
+    required:
+      - code
+      - message
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string


### PR DESCRIPTION
# Issue

The rule currently expects that the spec file input is in the same path as the rule.
You can demonstrate this by having your spec file in a nested directory and attempting to use it.
In order for it to build with the current setup, the output files must be prefixed with the path to the spec.

```
openapi_gen(
    name = "output_in_rule_di",
    language = "typescript-node",
    spec = "nested/under/several/directories/petstore.yaml",
    outputs = [
        # Must also all have the spec.dirname path to compile!
        "nested/under/several/directories/api.ts",
        "nested/under/several/directories/git_push.sh",
    ]
)
```

# Changes

I have based branch this ontop of https://github.com/vistarmedia/rules_openapi/pull/4 so that a test can be added against this bug.

The output files will now be created in the rules directory (inside bazel-bin).

Now you can simply do this 🎉

```
openapi_gen(
    name = "output_in_rule_di",
    language = "typescript-node",
    spec = "nested/under/several/directories/petstore.yaml",
    outputs = [
        "api.ts",
        "git_push.sh",
    ]
)
```