### PR TITLE
Remove legacy java provider

### DIFF
--- a/openapi/openapi.bzl
+++ b/openapi/openapi.bzl
@@ -125,13 +125,13 @@ def _collect_jars(targets):
             runtime_jars = depset(transitive = [runtime_jars, target.scala.transitive_runtime_deps])
             runtime_jars = depset(transitive = [runtime_jars, target.scala.transitive_runtime_exports])
             found = True
-        if hasattr(target, "java"):
+        if hasattr(target, "JavaInfo"):
             # see JavaSkylarkApiProvider.java,
             # this is just the compile-time deps
             # this should be improved in bazel 0.1.5 to get outputs.ijar
           # compile_jars = depset(transitive = [compile_jars, [target.java.outputs.ijar]])
-            compile_jars = depset(transitive = [compile_jars, target.java.transitive_deps])
-            runtime_jars = depset(transitive = [runtime_jars, target.java.transitive_runtime_deps])
+            compile_jars = depset(transitive = [compile_jars, target[JavaInfo].transitive_deps])
+            runtime_jars = depset(transitive = [runtime_jars, target[JavaInfo].transitive_runtime_deps])
             found = True
         if not found:
             # support http_file pointed at a jar. http_jar uses ijar,


### PR DESCRIPTION
This was removed in bazel 1.0